### PR TITLE
Update base to 22.04

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -7,9 +7,9 @@ parts:
 bases:
   - build-on:
     - name: ubuntu
-      channel: '20.04'
+      channel: '22.04'
       architectures: [amd64]
     run-on:
     - name: ubuntu
-      channel: '20.04'
+      channel: '22.04'
       architectures: [amd64]


### PR DESCRIPTION
Locally it passed tests, let's check on GH.

Otherwise GH publisher is not happy:
https://github.com/canonical/s3-integrator/actions/runs/4004942011

```
Run canonical/charming-actions/upload-charm@2.2.2
/usr/bin/sudo snap install charmcraft --classic --channel latest/stable
charmcraft 2.2.0 from Canonical** installed
/usr/bin/sudo charmcraft pack --quiet --destructive-mode
Error: No suitable 'build-on' environment found in any 'bases' configuration.
```