### PR TITLE
Remove enforcement of series in metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,9 +9,6 @@ description: |
 summary: |
   A provider charm for s3 credentials.
 
-series:
-  - focal
-
 peers:
   s3-integrator-peers:
     interface: s3-integrator-peers


### PR DESCRIPTION
# Issue
There is a metadata field defined for the `series` of the charm. When deployed in k8s, the pod is deployed with a focal image, but any actions run against the deployed charm hang (this does not happen when the series is undefined).

# Solution
Remove the `series` field in the metadata.

# Context
With `series` defined, the pod name is `s3-integrator-operator-0` (when the application name is `s3-integrator`). Without the `series` defined, it is `s3-integrator-0`. I am unsure if this is related or the cause of actions against the charm hanging.

# Release Notes
Remove enforcement of series in metadata