### PR TITLE
Avoid overwriting bucket name if set by config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ juju run-action s3-integrator/leader get-s3-connection-info --wait
 
 ## Relations 
 
-Relations are supported via the `s3-credentials` interface. To create a relation: 
+Relations are supported via the `s3` interface. To create a relation:
 
 ```bash
 $ juju relate s3-integrator application
@@ -77,3 +77,4 @@ Security issues in the Charmed S3 Integrator Operator can be reported through [L
 ## Contributing
 
 Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](https://github.com/canonical/s3-integrator/blob/main/CONTRIBUTING.md) for developer guidance.
+

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,4 +15,4 @@ peers:
 
 provides:
   s3-credentials:
-    interface: s3-credentials
+    interface: s3

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,7 +113,7 @@ class S3IntegratorCharm(ops.charm.CharmBase):
             return
         relation_id = event.relation.id
 
-        bucket =  self.get_secret("app", "bucket") or event.bucket
+        bucket = self.get_secret("app", "bucket") or event.bucket
 
         logger.debug(f"Desired bucket name: {bucket}")
         assert bucket is not None

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,7 +113,8 @@ class S3IntegratorCharm(ops.charm.CharmBase):
             return
         relation_id = event.relation.id
 
-        bucket = event.bucket
+        bucket =  self.get_secret("app", "bucket") or event.bucket
+
         logger.debug(f"Desired bucket name: {bucket}")
         assert bucket is not None
         # if bucket name is already specified ignore the one provided by the requirer app

--- a/tests/integration/application-charm/metadata.yaml
+++ b/tests/integration/application-charm/metadata.yaml
@@ -12,6 +12,6 @@ series:
 
 requires:
   first-s3-credentials:
-    interface: s3-credentials
+    interface: s3
   second-s3-credentials:
-    interface: s3-credentials
+    interface: s3

--- a/tests/integration/test_s3_charm.py
+++ b/tests/integration/test_s3_charm.py
@@ -221,7 +221,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert "secret-key" in application_data
     assert "bucket" in application_data
     # check correctness of connection parameters in the relation databag
-    assert application_data["bucket"] == "test-bucket"
+    assert application_data["bucket"] == new_bucket_name
     assert application_data["access-key"] == "test-access-key"
     assert application_data["secret-key"] == "new-test-secret-key"
     assert application_data["storage-class"] == "cinder"


### PR DESCRIPTION
Resolves [issue 5](https://github.com/canonical/s3-integrator/issues/5)

# Issue
- The `bucket` config value is overwritten with the relation name when credentials are requested by the related application charm.
- The interface name for this charm should be `s3` and not `s3-credentials`
 
# Solution
- Avoid overwriting the bucket value if it is set by the config.
- Update interface name to `s3`

# Release Notes
Avoid overwriting bucket name if set by config