### PR TITLE
Remove default value for endpoint

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,6 @@ options:
   endpoint:
     type: string
     description: The endpoint used to connect to the object storage.
-    default: 's3.amazonaws.com'
   bucket:
     type: string
     description: The bucket/container name delivered by the provider.


### PR DESCRIPTION
Rational: Some backup tools do not require an endpoint and it is impossible to determine whether the value for `endpoint` was purposefully set or automatically set.