### PR TITLE
DPE-1180 Fix display name: s/display_name/display-name/

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 name: s3-integrator
-display_name: S3 Integrator
+display-name: S3 Integrator
 summary: A provider charm for s3 credentials.
 description: |
   S3 Integrator is an integrator charm for providing S3 credentials to


### PR DESCRIPTION
The incorrect example taken from data-platform-libs, fixing in both places.

Specification: https://discourse.charmhub.io/t/file-metadata-yaml/5213#heading--display-name