### PR TITLE
Added status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # S3-integrator
+[![Charmhub](https://charmhub.io/s3-integrator/badge.svg)](https://charmhub.io/s3-integrator)
+[![Release](https://github.com/canonical/s3-integrator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/s3-integrator/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/s3-integrator/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/s3-integrator/actions/workflows/ci.yaml)
+
 ## Description
 
 An operator charm providing an integrator for connecting to S3 provides.


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* CharmHub
* Release
* Tests