### PR TITLE
[DPE-4401] Add retention config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To configure the S3 integrator charm, you may provide the following configuratio
 - storage-class:the storage class for objects uploaded to the object storage.
 - tls-ca-chain: the complete CA chain, which can be used for HTTPS validation.
 - s3-api-version: the S3 protocol specific API signature.
+- experimental-delete-older-than-days: the amount of day after which backups going to be deleted. EXPERIMENTAL option.
 
 The only mandatory fields for the integrator are access-key secret-key and bucket.
 

--- a/config.yaml
+++ b/config.yaml
@@ -36,3 +36,14 @@ options:
     type: string
     description: S3 protocol specific API signature.
     default: ''
+  experimental-delete-older-than-days:
+    type: string
+    description: |
+      Full backups can be retained for a number of days. The removal of expired
+      backups happens imediatelly after finishing the first successful backup after
+      retention period.
+      When full backup expires, the all differential and incremental backups which
+      depends on this full backup also expires.
+      This option is EXPRERIMENTAL.
+      Allowed values are: from 1 to 9999999.
+    default: ''

--- a/config.yaml
+++ b/config.yaml
@@ -37,7 +37,7 @@ options:
     description: S3 protocol specific API signature.
     default: ''
   experimental-delete-older-than-days:
-    type: string
+    type: int
     description: |
       Full backups can be retained for a number of days. The removal of expired
       backups happens imediatelly after finishing the first successful backup after
@@ -46,4 +46,3 @@ options:
       depends on this full backup also expires.
       This option is EXPRERIMENTAL.
       Allowed values are: from 1 to 9999999.
-    default: ''

--- a/src/charm.py
+++ b/src/charm.py
@@ -93,10 +93,15 @@ class S3IntegratorCharm(ops.charm.CharmBase):
                 if config_value > 0 and config_value <= MAX_RETENTION_DAYS:
                     update_config.update({option: str(config_value)})
                     self.set_secret("app", option, str(config_value))
+                    self.unit.status = ActiveStatus()
                 else:
                     logger.warning(
-                        "Invalid value %s for config 'delete-older-than-days', ignoring.",
+                        "Invalid value %s for config '%s'",
                         config_value,
+                        option,
+                    )
+                    self.unit.status = BlockedStatus(
+                        f"Option {option} value {config_value} outside allowed range [1, {MAX_RETENTION_DAYS}]."
                     )
                 continue
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -68,7 +68,7 @@ class S3IntegratorCharm(ops.charm.CharmBase):
         if missing_options:
             self.unit.status = ops.model.BlockedStatus(f"Missing parameters: {missing_options}")
 
-    def _on_config_changed(self, _: ConfigChangedEvent) -> None:
+    def _on_config_changed(self, _: ConfigChangedEvent) -> None:  # noqa: C901
         """Event handler for configuration changed events."""
         # Only execute in the unit leader
         if not self.unit.is_leader():
@@ -102,9 +102,12 @@ class S3IntegratorCharm(ops.charm.CharmBase):
                 )
                 update_config.update({option: ca_chain})
                 self.set_secret("app", option, json.dumps(ca_chain))
+            elif option == "experimental-delete-older-than-days" and self.config[option] != "":
+                update_config.update({"delete-older-than-days": str(self.config[option])})
+                self.set_secret("app", "delete-older-than-days", str(self.config[option]))
             else:
-                update_config.update({option: self.config[option]})
-                self.set_secret("app", option, self.config[option])
+                update_config.update({option: str(self.config[option])})
+                self.set_secret("app", option, str(self.config[option]))
 
         if len(self.s3_provider.relations) > 0:
             for relation in self.s3_provider.relations:

--- a/src/charm.py
+++ b/src/charm.py
@@ -79,7 +79,7 @@ class S3IntegratorCharm(ops.charm.CharmBase):
 
         # iterate over the option and check for updates
         for option in S3_OPTIONS:
-            # experimental options should be handled from the config with the "experimental-" prefix
+            # experimental config options should be handled with the "experimental-" prefix
             if option == "delete-older-than-days" and f"experimental-{option}" in self.config:
                 config_value = str(self.config[f"experimental-{option}"])
                 # reset value if empty config_value

--- a/src/constants.py
+++ b/src/constants.py
@@ -24,3 +24,4 @@ S3_MANDATORY_OPTIONS = [
 ]
 S3_LIST_OPTIONS = ["attributes", "tls-ca-chain"]
 KEYS_LIST = ["access-key", "secret-key"]
+MAX_RETENTION_DAYS = 9999999

--- a/src/constants.py
+++ b/src/constants.py
@@ -16,6 +16,7 @@ S3_OPTIONS = [
     "s3-api-version",
     "s3-uri-style",
     "tls-ca-chain",
+    "delete-older-than-days",
 ]
 S3_MANDATORY_OPTIONS = [
     "access-key",

--- a/tests/integration/test_s3_charm.py
+++ b/tests/integration/test_s3_charm.py
@@ -138,7 +138,7 @@ async def test_config_options(ops_test: OpsTest):
         "path": "/test/path_1/",
         "region": "us-east-2",
         "endpoint": "s3.amazonaws.com",
-        "experimental-delete-older-than-days": "7",
+        "experimental-delete-older-than-days": 7,
     }
     # apply new configuration options
     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
@@ -152,7 +152,7 @@ async def test_config_options(ops_test: OpsTest):
     # test the correctness of the configuration fields
     assert configured_options["storage-class"] == "cinder"
     assert configured_options["s3-api-version"] == "1.0"
-    assert configured_options["delete-older-than-days"] == "7"
+    assert configured_options["delete-older-than-days"] == 7
     assert len(json.loads(configured_options["attributes"])) == 3
     assert len(json.loads(configured_options["tls-ca-chain"])) == 2
     assert configured_options["region"] == "us-east-2"
@@ -189,7 +189,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert application_data["secret-key"] == "new-test-secret-key"
     assert application_data["storage-class"] == "cinder"
     assert application_data["s3-api-version"] == "1.0"
-    assert application_data["delete-older-than-days"] == "7"
+    assert application_data["delete-older-than-days"] == 7
     assert len(json.loads(application_data["attributes"])) == 3
     assert len(json.loads(application_data["tls-ca-chain"])) == 2
     assert application_data["region"] == "us-east-2"
@@ -226,7 +226,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert application_data["secret-key"] == "new-test-secret-key"
     assert application_data["storage-class"] == "cinder"
     assert application_data["s3-api-version"] == "1.0"
-    assert application_data["delete-older-than-days"] == "7"
+    assert application_data["delete-older-than-days"] == 7
     assert len(json.loads(application_data["attributes"])) == 3
     assert len(json.loads(application_data["tls-ca-chain"])) == 2
     assert application_data["region"] == "us-east-2"

--- a/tests/integration/test_s3_charm.py
+++ b/tests/integration/test_s3_charm.py
@@ -138,7 +138,7 @@ async def test_config_options(ops_test: OpsTest):
         "path": "/test/path_1/",
         "region": "us-east-2",
         "endpoint": "s3.amazonaws.com",
-        "delete-older-than-days": "30",
+        "experimental-delete-older-than-days": "30",
     }
     # apply new configuration options
     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)

--- a/tests/integration/test_s3_charm.py
+++ b/tests/integration/test_s3_charm.py
@@ -138,6 +138,7 @@ async def test_config_options(ops_test: OpsTest):
         "path": "/test/path_1/",
         "region": "us-east-2",
         "endpoint": "s3.amazonaws.com",
+        "delete-older-than-days": "30",
     }
     # apply new configuration options
     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
@@ -151,6 +152,7 @@ async def test_config_options(ops_test: OpsTest):
     # test the correctness of the configuration fields
     assert configured_options["storage-class"] == "cinder"
     assert configured_options["s3-api-version"] == "1.0"
+    assert configured_options["delete-older-than-days"] == "7"
     assert len(json.loads(configured_options["attributes"])) == 3
     assert len(json.loads(configured_options["tls-ca-chain"])) == 2
     assert configured_options["region"] == "us-east-2"
@@ -187,6 +189,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert application_data["secret-key"] == "new-test-secret-key"
     assert application_data["storage-class"] == "cinder"
     assert application_data["s3-api-version"] == "1.0"
+    assert application_data["delete-older-than-days"] == "7"
     assert len(json.loads(application_data["attributes"])) == 3
     assert len(json.loads(application_data["tls-ca-chain"])) == 2
     assert application_data["region"] == "us-east-2"
@@ -223,6 +226,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert application_data["secret-key"] == "new-test-secret-key"
     assert application_data["storage-class"] == "cinder"
     assert application_data["s3-api-version"] == "1.0"
+    assert application_data["delete-older-than-days"] == "7"
     assert len(json.loads(application_data["attributes"])) == 3
     assert len(json.loads(application_data["tls-ca-chain"])) == 2
     assert application_data["region"] == "us-east-2"

--- a/tests/integration/test_s3_charm.py
+++ b/tests/integration/test_s3_charm.py
@@ -138,7 +138,7 @@ async def test_config_options(ops_test: OpsTest):
         "path": "/test/path_1/",
         "region": "us-east-2",
         "endpoint": "s3.amazonaws.com",
-        "experimental-delete-older-than-days": 7,
+        "experimental-delete-older-than-days": "7",
     }
     # apply new configuration options
     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
@@ -152,7 +152,7 @@ async def test_config_options(ops_test: OpsTest):
     # test the correctness of the configuration fields
     assert configured_options["storage-class"] == "cinder"
     assert configured_options["s3-api-version"] == "1.0"
-    assert configured_options["delete-older-than-days"] == 7
+    assert configured_options["delete-older-than-days"] == "7"
     assert len(json.loads(configured_options["attributes"])) == 3
     assert len(json.loads(configured_options["tls-ca-chain"])) == 2
     assert configured_options["region"] == "us-east-2"
@@ -189,7 +189,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert application_data["secret-key"] == "new-test-secret-key"
     assert application_data["storage-class"] == "cinder"
     assert application_data["s3-api-version"] == "1.0"
-    assert application_data["delete-older-than-days"] == 7
+    assert application_data["delete-older-than-days"] == "7"
     assert len(json.loads(application_data["attributes"])) == 3
     assert len(json.loads(application_data["tls-ca-chain"])) == 2
     assert application_data["region"] == "us-east-2"
@@ -226,7 +226,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert application_data["secret-key"] == "new-test-secret-key"
     assert application_data["storage-class"] == "cinder"
     assert application_data["s3-api-version"] == "1.0"
-    assert application_data["delete-older-than-days"] == 7
+    assert application_data["delete-older-than-days"] == "7"
     assert len(json.loads(application_data["attributes"])) == 3
     assert len(json.loads(application_data["tls-ca-chain"])) == 2
     assert application_data["region"] == "us-east-2"

--- a/tests/integration/test_s3_charm.py
+++ b/tests/integration/test_s3_charm.py
@@ -138,7 +138,7 @@ async def test_config_options(ops_test: OpsTest):
         "path": "/test/path_1/",
         "region": "us-east-2",
         "endpoint": "s3.amazonaws.com",
-        "experimental-delete-older-than-days": "30",
+        "experimental-delete-older-than-days": "7",
     }
     # apply new configuration options
     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)


### PR DESCRIPTION
## Motivation

Link to issue: https://warthogs.atlassian.net/browse/DPE-4401
Link to spec: https://docs.google.com/document/d/1WWMt_Q71cUIrpfYirp5TRCdkJXMjFSWCH6CTnKrO4YA/edit

## Solution

- Adds a new experimental configuration parameter: `experimental-delete-older-than-days` that will get transmitted to related postgresql charms via relation data.
- Includes `data_platform_libs` patch from https://github.com/canonical/data-platform-libs/pull/168
- Adapt tests accordingly