### PR TITLE
Add config options for access-key, secret-key

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,8 +53,8 @@ options:
       This config option takes precedence over values passed via the sync-s3-credentials action.
       This value must be unset for the action to have effect.
   secret-key:
-  type: string
-  description: |
-    Access Key Secret (password) for connecting to the object storage.
-    This config option takes precedence over values passed via the sync-s3-credentials action.
-    This value must be unset for the action to have effect.
+    type: string
+    description: |
+      Access Key Secret (password) for connecting to the object storage.
+      This config option takes precedence over values passed via the sync-s3-credentials action.
+      This value must be unset for the action to have effect.

--- a/config.yaml
+++ b/config.yaml
@@ -46,3 +46,15 @@ options:
       depends on this full backup also expires.
       This option is EXPRERIMENTAL.
       Allowed values are: from 1 to 9999999.
+  access-key:
+    type: string
+    description: |
+      Access Key (account) for connecting to the object storage.
+      This config option takes precedence over values passed via the sync-s3-credentials action.
+      This value must be unset for the action to have effect.
+  secret-key:
+  type: string
+  description: |
+    Access Key Secret (password) for connecting to the object storage.
+    This config option takes precedence over values passed via the sync-s3-credentials action.
+    This value must be unset for the action to have effect.

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,7 +113,7 @@ class S3IntegratorCharm(ops.charm.CharmBase):
                 if option in KEYS_LIST:
                     logger.debug("Secret parameter %s not stored inside config.", option)
                     # This will be called twice, but it's ok because ops buffers relation writes.
-                    self._sync_s3_credentials(self.config["access-key"], self.config["secret-key"])
+                    self._sync_s3_credentials(self.config.get("access-key"), self.config.get("secret-key"))
                     continue
                 # reset previous config value if present
                 if self.get_secret("app", option) is not None:
@@ -216,7 +216,7 @@ class S3IntegratorCharm(ops.charm.CharmBase):
         if not self.unit.is_leader():
             event.fail("The action can be run only on leader unit.")
             return
-        if self.config["access-key"] or self.config["secret-key"]:
+        if self.config.get("access-key") or self.config.get("secret-key"):
             event.fail(
                 "Config options for access-key, secret-key take precedence over the action. "
                 "Unset the config options to use this action."

--- a/src/charm.py
+++ b/src/charm.py
@@ -112,6 +112,8 @@ class S3IntegratorCharm(ops.charm.CharmBase):
             if option not in self.config or self.config[option] == "":
                 if option in KEYS_LIST:
                     logger.debug("Secret parameter %s not stored inside config.", option)
+                    # This will be called twice, but it's ok because ops buffers relation writes.
+                    self._sync_s3_credentials(self.config["access-key"], self.config["secret-key"])
                     continue
                 # reset previous config value if present
                 if self.get_secret("app", option) is not None:
@@ -131,9 +133,6 @@ class S3IntegratorCharm(ops.charm.CharmBase):
                 )
                 update_config.update({option: ca_chain})
                 self.set_secret("app", option, json.dumps(ca_chain))
-            elif option in ["access-key", "secret-key"]:
-                # This will be called twice, but it's ok because ops buffers relation writes.
-                self._sync_s3_credentials(self.config["access-key"], self.config["secret-key"])
             else:
                 update_config.update({option: str(self.config[option])})
                 self.set_secret("app", option, str(self.config[option]))

--- a/src/charm.py
+++ b/src/charm.py
@@ -114,7 +114,7 @@ class S3IntegratorCharm(ops.charm.CharmBase):
             if option not in self.config or self.config[option] == "":
                 if option in KEYS_LIST:
                     # We will reset credentials only if the config options is given, because we do
-                    # not want to accidentally wipe credentials previsouly set by the sync action.
+                    # not want to accidentally wipe credentials previously set by the sync action.
                     logger.debug("Secret parameter %s not stored inside config.", option)
                     continue
                 # reset previous config value if present
@@ -137,7 +137,7 @@ class S3IntegratorCharm(ops.charm.CharmBase):
                 self.set_secret("app", option, json.dumps(ca_chain))
             elif option in ["access-key", "secret-key"]:
                 # We sync credentials only if one of the config options is given, because we do
-                # not want to accidentally wipe credentials previsouly set by the sync action.
+                # not want to accidentally wipe credentials previously set by the sync action.
                 access_key = self.config.get("access-key")
                 secret_key = self.config.get("secret-key")
                 if access_key or secret_key:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -62,7 +62,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
         action_event = mock.Mock()
         action_event.params = {"access-key": "test-access-key", "secret-key": "test-secret-key"}
-        self.harness.charm._on_sync_s3_credentials(action_event)
+        self.harness.charm._on_sync_s3_credentials_action(action_event)
 
         access_key = self.harness.charm.app_peer_data["access-key"]
         secret_key = self.harness.charm.app_peer_data["secret-key"]


### PR DESCRIPTION
## Problem
For COS we're now using s3-integrator in all deployments.
With terraform, running actions on a deployment is a bit involved.

## Solution
Add config options for access-key, secret-key.
Since the secrets are already stored in reldata, not much additional harm having them also in the config.
Fixes #62.

### Side-effect
Since we can now have credentials from two sources (action, config), the new logic introduced in this PR has a new side effect: even when the config options are cleared via
```bash
juju config s3i access-key= secret-key=
# or
juju config s3i --reset access-key,secret-key
```
the credentials still stay in app data. To clear app data after config values were cleared, we'd need to follow-up with the action,
```bash
juju run s3i/0 sync-s3-credentials access-key= secret-key=
```