### PR TITLE
do not log sensitive information

### DIFF
--- a/lib/charms/data_platform_libs/v0/s3.py
+++ b/lib/charms/data_platform_libs/v0/s3.py
@@ -354,7 +354,7 @@ class S3Provider(Object):
                 updated_connection_data[configuration_option] = configuration_value
 
         relation.data[self.local_app].update(updated_connection_data)
-        logger.debug(f"Updated S3 connection info: {updated_connection_data}")
+        logger.debug("Updated S3 connection info.")
 
     @property
     def relations(self) -> List[Relation]:
@@ -721,7 +721,7 @@ class S3Requirer(Object):
                 updated_connection_data[configuration_option] = configuration_value
 
         relation.data[self.local_app].update(updated_connection_data)
-        logger.debug(f"Updated S3 credentials: {updated_connection_data}")
+        logger.debug("Updated S3 credentials.")
 
     def _load_relation_data(self, raw_relation_data: RelationDataContent) -> Dict[str, str]:
         """Loads relation data from the relation data bag.


### PR DESCRIPTION
Currently the S3-integrator charm writes sensitive information to the debug log output:

```
unit-s3-integrator-5: 15:37:59 DEBUG unit.s3-integrator/5.juju-log s3-credentials:72: Updated S3 connection info: {'access-key': '9B523.....', 'secret-key': 'oTx1...', 'bucket': 'test-bucket-2', 'endpoint': [...]
```

This should not happen to avoid leaking secret information.